### PR TITLE
Put global declared objects (attribute creator) into the anonymous namespace

### DIFF
--- a/iod.hh
+++ b/iod.hh
@@ -174,6 +174,6 @@ template <int serializable>                                             \
   static auto accessor(T t) -> decltype(t.NAME) { return t.NAME; }      \
   inline static const char* attribute_name() { return #NAME; }          \
 };                                                                      \
-NAME##_attribute_name<0> NAME;
+namespace { NAME##_attribute_name<0> NAME; }
 
 #endif


### PR DESCRIPTION
The problem here is that if you use the same attribute name in two compilation units (which is likely), the linker will fail on duplicated symbols error, because of the globally declared objects. Putting them in the anonymous namespace makes it work.
