### PR TITLE
Explicit #include for std::string

### DIFF
--- a/iod/grammar.hh
+++ b/iod/grammar.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <string>
 #include <vector>
 #include <initializer_list>
 #include <iod/foreach.hh>


### PR DESCRIPTION
This can bite you depending on how your headers are organized