### PR TITLE
Adding Travis-CI integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 *.exe
 *.out
 *.app
+
+# CMake build files
+build/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ matrix:
         sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.8', 'boost-latest']
         packages: ['clang-3.8', 'libboost1.54-dev']
     env: COMPILER=clang++-3.8
+  - os: osx
+    osx_image: xcode7.3
+    compiler: clang
+    env: COMPILER=clang++
 
 script:
 - export CXX=${COMPILER}

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,15 @@ matrix:
     compiler: gcc
     addons:
       apt:
-        sources: ['ubuntu-toolchain-r-test']
-        packages: ['g++-6', 'libboost-dev']
+        sources: ['ubuntu-toolchain-r-test', 'boost-latest']
+        packages: ['g++-6', 'libboost1.54-dev']
     env: COMPILER=g++-6
   - os: linux
     compiler: clang
     addons:
       apt:
-        sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.8']
-        packages: ['clang-3.8', 'libboost-dev']
+        sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.8', 'boost-latest']
+        packages: ['clang-3.8', 'libboost1.54-dev']
     env: COMPILER=clang++-3.8
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
 script:
 - export CXX=${COMPILER}
 - ${CXX} --version
-- cd build
+- mkdir -p build && cd build
 - cmake .. && make -j4
 - cd tests
-- CTEST_OUTPUT_ON_FAILURE=1 ctest
+- ctest --output-on-failure

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: cpp
+
+matrix:
+  include:
+  - os: linux
+    compiler: gcc
+    addons:
+      apt:
+        sources: ['ubuntu-toolchain-r-test']
+        packages: ['g++-6', 'libboost-dev']
+    env: COMPILER=g++-6
+  - os: linux
+    compiler: clang
+    addons:
+      apt:
+        sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.8']
+        packages: ['clang-3.8', 'libboost-dev']
+    env: COMPILER=clang++-3.8
+
+script:
+- export CXX=${COMPILER}
+- ${CXX} --version
+- cd build
+- cmake .. && make -j4
+- cd tests
+- CTEST_OUTPUT_ON_FAILURE=1 ctest

--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 
 enable_testing()
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/..)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/.. ${Boost_INCLUDE_DIRS})
 add_definitions(-std=c++14 -Wall)
 
 #add_executable(iod_query_stl iod_query_stl.cc)


### PR DESCRIPTION
Added the required `.travis.yml` configuration file to build on Linux using sufficiently new versions of gcc or clang. You can enable this in GitHub integrations and services to run CI tests on all commits/PRs.

This can also be extended to get code coverage numbers from the tests run.
Please let me know if there are more changes required from my side.

Thanks.