### PR TITLE
Declare `detect_encoding(…)` as inline

### DIFF
--- a/iod/json_unicode.hh
+++ b/iod/json_unicode.hh
@@ -101,7 +101,7 @@ namespace iod
 
   // Detection of encoding depending on the pattern of the
   // first fourth characters.
-  auto detect_encoding(char a, char b, char c, char d)
+  inline auto detect_encoding(char a, char b, char c, char d)
   {
     // 00 00 00 xx  UTF-32BE
     // xx 00 00 00  UTF-32LE


### PR DESCRIPTION
Without marking this function as `inline`, I get duplicate-symbol errors at link-time for the compiled artifacts of any code that had made use of IOD. This one change fixed the problem.