### PR TITLE
improvement: compiles on MSVC also

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,6 @@ project(Iod)
 find_package(Boost REQUIRED) # For lexical_cast
 
 set(CMAKE_CXX_STANDARD 14)
-add_definitions(-std=c++14) # For old cmake versions
 
 install(DIRECTORY iod DESTINATION include
   FILES_MATCHING PATTERN "*.hh")

--- a/iod/aos_view.hh
+++ b/iod/aos_view.hh
@@ -111,7 +111,7 @@ namespace iod
     bool check_sizes()
     {
       // Check if array have the same sizes.
-      int s = size();
+      int s = static_cast<int>(size());
       bool res = true;
       foreach(arrays) | [&res, s] (auto m)
       {
@@ -128,19 +128,19 @@ namespace iod
     // Get the size of the AOS.
     size_t size() const {
       if (hand_set_size > -1)
-        return hand_set_size;
+        return static_cast<size_t>(hand_set_size);
 
       int res = -1;
       foreach(arrays) | [&res] (auto m)
       {
         static_if<has_size_method<std::remove_reference_t<decltype(m.value())>>::value>(
-          [&res] (auto m) { res = m.value().size(); },
+          [&res] (auto m) { res = static_cast<int>(m.value().size()); },
           [] (auto) { },
           m);
       };
 
       assert(res >= 0 && "At least one array with a size method is needed");
-      return res;
+      return static_cast<size_t>(res);
     }
 
     // Access to the ith element.
@@ -155,7 +155,7 @@ namespace iod
 
     // iterators for range based for loops.
     auto begin() { return iterator(*this, 0); }
-    auto end() { return iterator(*this, size()); }
+    auto end() { return iterator(*this, static_cast<int>(size())); }
 
   private:
     // Helper to access the ith element, whether the set
@@ -179,7 +179,7 @@ namespace iod
                   [i] (auto m) { return bind_first_arg(m, i, (callable_arguments_tuple_t<F>*)0); },
                   m);
               },
-              [i] (auto&& m) -> decltype(auto) { return m[i];},
+              [i] (auto&& m) -> decltype(auto) { return m[static_cast<size_t>(i)];},
               S().member_access(arrays)));
     }
 

--- a/iod/apply.hh
+++ b/iod/apply.hh
@@ -64,10 +64,10 @@ namespace iod
     // tuples.
     template <typename... M, typename... T>
     static decltype(auto) run(std::tuple<M...>& o, T&&... t)
-    { return run_tuple<N, sizeof...(M)>::run(o, std::forward<T>(t)...); }
+    { return run_tuple<N, static_cast<int>(sizeof...(M))>::run(o, std::forward<T>(t)...); }
     template <typename... M, typename... T>
     static decltype(auto) run(const std::tuple<M...>& o, T&&... t)
-    { return run_tuple<N, sizeof...(M)>::run(o, std::forward<T>(t)...); }
+    { return run_tuple<N, static_cast<int>(sizeof...(M))>::run(o, std::forward<T>(t)...); }
   
     // Other types
     template <typename T1, typename... T>
@@ -111,7 +111,7 @@ namespace iod
   template <typename... T>
   decltype(auto) apply(T&&... t)
   {
-    return run_apply<sizeof...(T) - 1>::run(std::forward<T>(t)...);
+    return run_apply<static_cast<int>(sizeof...(T) - 1)>::run(std::forward<T>(t)...);
   }
   
   

--- a/iod/array_view.hh
+++ b/iod/array_view.hh
@@ -27,7 +27,7 @@ namespace iod
 
     auto size() const { return view.size(); }
     auto begin() { return aos_view_iterator<self_t>(*this, 0); }
-    auto end() { return aos_view_iterator<self_t>(*this, view.size()); }
+    auto end() { return aos_view_iterator<self_t>(*this, static_cast<int>(view.size())); }
 
     V view;
   };

--- a/iod/foreach.hh
+++ b/iod/foreach.hh
@@ -22,7 +22,7 @@ namespace iod
       return f(std::get<N>(ts)...);
     }
 
-    template<typename Ret, typename F, size_t... TSize, size_t... Nargs, typename... T>
+    template<typename Ret, typename F, size_t... TSize, typename... T>
     inline void
     tuple_foreach_impl(std::enable_if_t<std::is_same<void, Ret>::value>*,
                        std::index_sequence<TSize...>,
@@ -32,7 +32,7 @@ namespace iod
         ((void)tuple_foreach_i<TSize>(f, std::forward<T>(ts)...), 0)...};
     }
 
-    template<typename Ret, typename F, size_t... TSize, size_t... Nargs, typename... T>
+    template<typename Ret, typename F, size_t... TSize, typename... T>
     inline decltype(auto)
       tuple_foreach_impl(std::enable_if_t<!std::is_same<void, Ret>::value>*,
                          std::index_sequence<TSize...>,
@@ -48,7 +48,7 @@ namespace iod
       return f(ts.template get_nth_member<N>()...);
     }
 
-    template<typename Ret, typename F, size_t... TSize, size_t... Nargs, typename... T>
+    template<typename Ret, typename F, size_t... TSize, typename... T>
     inline void
     sio_foreach_impl(std::enable_if_t<std::is_same<void, Ret>::value>*,
                      std::index_sequence<TSize...>,
@@ -58,7 +58,7 @@ namespace iod
         ((void)sio_foreach_i<TSize>(f, std::forward<T>(ts)...), 0)...};
     }
 
-    template<typename Ret, typename F, size_t... TSize, size_t... Nargs, typename... T>
+    template<typename Ret, typename F, size_t... TSize, typename... T>
     inline decltype(auto)
     sio_foreach_impl(std::enable_if_t<!std::is_same<void, Ret>::value>*,
                      std::index_sequence<TSize...> /*si*/,

--- a/iod/json.hh
+++ b/iod/json.hh
@@ -71,7 +71,7 @@ namespace iod
       {
         if (pos_ + s.size() > max_len_)
           throw std::runtime_error("Maximum json string lenght reached during encoding.");
-        memcpy(buf_ + pos_, s.data(), s.size());
+        memcpy(buf_ + pos_, s.data(), static_cast<size_t>(s.size()));
         pos_ += s.size();
       }
 
@@ -88,7 +88,7 @@ namespace iod
 
       stringstream(int hint_size = 10)
         : pos_(0)
-      { str_.reserve(hint_size); }
+      { str_.reserve(static_cast<size_t>(hint_size)); }
 
       inline void append(const char t)
       {
@@ -108,20 +108,20 @@ namespace iod
           flush();
           int to_write = std::min(int(end - begin), LBS);
           
-          memcpy(buf_, begin, to_write);
+          memcpy(buf_, begin, static_cast<size_t>(to_write));
           begin += to_write;
           pos_ += to_write;
         }
 
-        memcpy(buf_ + pos_, begin, end - begin);
+        memcpy(buf_ + pos_, begin, static_cast<size_t>(end - begin));
 
-        pos_ += end - begin;
+        pos_ += static_cast<int>(end - begin);
       }
 
       inline void flush()
       {
-        str_.resize(str_.size() + pos_);
-        memcpy(&(str_)[0] + str_.size() - pos_, buf_, pos_);
+        str_.resize(str_.size() + static_cast<std::string::size_type>(pos_));
+        memcpy(&(str_)[0] + str_.size() - pos_, buf_, static_cast<size_t>(pos_));
         pos_ = 0;
       }
 
@@ -275,7 +275,7 @@ namespace iod
 
     template <typename T>
     struct fill_ {
-      inline fill_(T& _r) : r(_r) {}
+      inline fill_(T& _rin) : r(_rin) {}
       T& r;
     };
 
@@ -287,9 +287,9 @@ namespace iod
     {
       struct spaces_ {} spaces;
 
-      inline json_parser(std::istringstream& _stream) : str(_stream.str()), pos(0) {}
-      inline json_parser(const std::string& _str) : str(_str.c_str(), _str.size()), pos(0) {}
-      inline json_parser(const stringview& _str) : str(_str), pos(0) {}
+      inline json_parser(std::istringstream& _istringstream) : str(_istringstream.str()), pos(0) {}
+      inline json_parser(const std::string& _sv) : str(_sv.c_str(), _sv.size()), pos(0) {}
+      inline json_parser(const stringview& _sv) : str(_sv), pos(0) {}
 
       inline char peek() { return str[pos]; }
       inline char eof() { return pos == str.size(); }
@@ -411,7 +411,7 @@ namespace iod
         // }
         // flush();
         // pos = end;
-        return *this;
+        // return *this;
       }
       
       inline json_parser& fill(stringview& t)
@@ -435,7 +435,7 @@ namespace iod
         }
 
         t.str = str.data() + start;
-        t.len = end - start;
+        t.len = static_cast<size_t>(end - start);
         pos = end;
         return *this;
       }
@@ -443,31 +443,59 @@ namespace iod
       template <typename I, int N>
       inline json_parser& fill_int(I& val)
       {
-        int sign = 1;
-        if (std::is_signed<I>::value and str[pos] == '-') { sign = -1; eat_one(); }
-        else if (str[pos] == '+') { eat_one(); }
+          if constexpr (std::is_signed<I>::value)
+          {
+             int sign = 1;
+             if (str[pos] == '-') { sign = -1; eat_one(); }
+             else if (str[pos] == '+') { eat_one(); }
+             int end = pos;
 
-        int end = pos;
-          
-        val = 0;
+             val = 0;
 
-        const char* s = str.data() + pos;
-        
-        int fz = 0;
-        while(s[fz] == '0') { fz++; end++; }
-        
-        for (int i = fz; i < N + fz; i++)
-        {
-          if (s[i] < '0' or s[i] > '9') break;
-          val = val * 10 + (s[i] - '0');
-          end++;
-        }
-        val *= sign;
+             const char* s = str.data() + pos;
 
-        if (end == pos) throw json_error("Could not find the expected number.");
-        
-        pos = end;
-        return *this;
+             int fz = 0;
+             while (s[fz] == '0') { fz++; end++; }
+
+             for (int i = fz; i < N + fz; i++)
+             {
+                if (s[i] < '0' or s[i] > '9') break;
+                val = val * 10 + (s[i] - '0');
+                end++;
+             }
+
+             val *= sign;
+
+             if (end == pos) throw json_error("Could not find the expected number.");
+
+             pos = end;
+          }
+          else 
+          {
+             if (str[pos] == '+') { eat_one(); }
+           
+             int end = pos;
+           
+             val = 0;
+           
+             const char* s = str.data() + pos;
+           
+             int fz = 0;
+             while (s[fz] == '0') { fz++; end++; }
+           
+             for (int i = fz; i < N + fz; i++)
+             {
+                if (s[i] < '0' or s[i] > '9') break;
+                val = val * 10U + static_cast<unsigned int>(s[i] - '0');
+                end++;
+             }
+
+             if (end == pos) throw json_error("Could not find the expected number.");
+
+             pos = end;
+          }
+
+          return *this;
       }
       
       inline json_parser& fill(float& val)
@@ -482,7 +510,7 @@ namespace iod
         if (str[pos] != '.')
           fill_int<int, 10>(ent);
 
-        res = ent;
+        res = static_cast<float>(ent);
 
         if (str[pos] == '.')
         {
@@ -491,7 +519,7 @@ namespace iod
           int start = pos;
           fill_int<unsigned int, 10>(floating);
           int end = pos;
-          res += float(floating) / pow_10(end - start);
+          res += static_cast<float>(floating / pow_10(end - start));
         }
 
         if (str[pos] == 'e')
@@ -499,10 +527,10 @@ namespace iod
           eat_one();
           int exp = 0;
           fill_int<int, 10>(exp);
-          res *= pow_10(exp);
+          res *= static_cast<float>(pow_10(exp));
         }
 
-        val = sign * res;
+        val = static_cast<float>(sign) * res;
         return *this;
       }
       
@@ -545,8 +573,8 @@ namespace iod
           if (str[pos] == '"') // strings.
           {
             pos++;
-            stringview str;
-            this->fill(str);
+            stringview sv;
+            this->fill(sv);
           }
           else if (str[pos] == '{' ) // start a json object
             parent_level++;
@@ -564,8 +592,8 @@ namespace iod
         }
 
         end = pos;
-        t.str.resize(end - start);
-        memcpy((void*)t.str.data(), (void*) (str.data() + start), end - start);
+        t.str.resize(static_cast<size_t>(end - start));
+        memcpy(static_cast<void*>(t.str.data()), static_cast<void const*>(str.data() + start), static_cast<size_t>(end - start));
         return *this;
       }
       
@@ -670,18 +698,18 @@ namespace iod
       attr_info A[sio<T, Tail...>::size()];
 
       sio<T, Tail...> scheme;// = *(sio<T, Tail...>*)(42);
-      int i = 0;
+      int ai = 0;
       foreach(scheme) | [&] (const auto& m)
       {
-        A[i].filled = false;
+        A[ai].filled = false;
         stringview name(m.symbol().name(), strlen(m.symbol().name()));
         if (m.attributes().has(_json_key))
         {
           const char* new_name = m.attributes().get(_json_key, _json_key).name();
           name = stringview(new_name, strlen(new_name));
         }
-        A[i].name = name;
-        i++;
+        A[ai].name = name;
+        ai++;
       };
 
       while (p.peek() != '}')
@@ -727,12 +755,12 @@ namespace iod
         throw p.json_error("Expected } got ", p.peek());
       }
 
-      i = 0;
+      ai = 0;
       foreach(scheme) | [&] (auto& m) {
-        if (!m.attributes().has(_json_skip) and !m.attributes().has(_optional) and !A[i].filled)
+        if (!m.attributes().has(_json_skip) and !m.attributes().has(_optional) and !A[ai].filled)
           throw std::runtime_error(std::string("json_decode error: missing field ") +
                                    m.symbol().name());
-        i++;
+        ai++;
       };
     }
     

--- a/iod/options.hh
+++ b/iod/options.hh
@@ -27,7 +27,7 @@ namespace iod
   template <typename... ARGS>
   auto parse_option(const std::tuple<ARGS...>& e)
   {
-    return apply(e, options_caller);
+    return iod::apply(e, options_caller);
   }
   
   template <typename S, typename... ARGS>

--- a/iod/parse_command_line.hh
+++ b/iod/parse_command_line.hh
@@ -21,7 +21,7 @@ namespace iod
     for (int ai = 1; ai < argc; ai++)
     {
       const char* arg = argv[ai];
-      int len = strlen(arg);
+      int len = static_cast<int>(strlen(arg));
 
       int ndash = 0;
       
@@ -37,9 +37,9 @@ namespace iod
         {
           if (arg_name[i] == '=')
           {
-            arg_name = stringview(arg_name.str, i);
+            arg_name = stringview(arg_name.str, static_cast<size_t>(i));
             arg = arg_name.str + i + 1;
-            len = strlen(arg);
+            len = static_cast<int>(strlen(arg));
             break;
           }
         }
@@ -63,7 +63,7 @@ namespace iod
 
       if (arg[0] != '-')
       {
-        auto value = stringview(arg, len);
+        auto value = stringview(arg, static_cast<size_t>(len));
         if (arg_name.data())
         {
           assert(args_map[arg_name.to_std_string()].size() > 0);

--- a/iod/sio.hh
+++ b/iod/sio.hh
@@ -151,21 +151,26 @@ namespace iod
     template <std::size_t N>
     using nth_member_type = tl::get_nth_type<N, Ms...>;
 
-    // Get the position of a given symbol    
-    template <typename S>
+    template <typename T> struct pack
+    {
+        typedef typename T::symbol_type symbol_type;
+    };
+
+    // get the position of a given symbol    
+    template <typename s>
     using symbol_to_member_type = nth_member_type<
-      tl::get_type_position<S, typename Ms::symbol_type...>::value
+      tl::get_type_position<s, typename pack<Ms>::symbol_type...>::value
                                   >;
     
-    // Get the value type of a diven symbol.
-    template <typename S>
-    using member_value_type = typename symbol_to_member_type<S>::value_type;
+    // get the value type of a diven symbol.
+    template <typename s>
+    using member_value_type = typename symbol_to_member_type<s>::value_type;
 
-    // template <int V>
-    // struct simple_enum { enum { value = V}; };
+    template <int v>
+    struct simple_enum { enum { value = v}; };
     
     template <typename S>
-    using _has = std::integral_constant<bool, tl::type_list_has<S, typename Ms::symbol_type...>::value>;
+    using _has = std::integral_constant<bool, tl::type_list_has<S, typename pack<Ms>::symbol_type...>::value>;
 
     // Constructor.
     inline sio() = default;

--- a/iod/stringview.hh
+++ b/iod/stringview.hh
@@ -12,7 +12,7 @@ namespace iod
     stringview() : str(0), len(0) {}
     stringview(const std::string& _str) : str(&_str[0]), len(_str.size()) {}
     stringview(const char* _str, std::size_t _len) : str(_str), len(_len) {}
-    stringview(const char* _begin, const char* _end) : str(_begin), len(_end - _begin) { assert(_end >= _begin); }
+    stringview(const char* _begin, const char* _end) : str(_begin), len(static_cast<size_t>(_end - _begin)) { assert(_end >= _begin); }
     stringview(const char* _str) : str(_str), len(strlen(_str)) {}
       
     bool operator==(const stringview& o) const { return len == o.len and !strncmp(o.str, str, len); }
@@ -25,11 +25,11 @@ namespace iod
     auto& operator[](int p) { return str[p]; }
     const auto& operator[](int p) const { return str[p]; }
 
-    int size() const { return len; }
+    int size() const { return static_cast<int>(len); }
     const char* data() const { return str; }
     auto to_std_string() const { return std::string(str, len); }
 
-    auto substr(int start, int new_len) { return stringview(str + start, new_len); }
+    auto substr(int start, int new_len) { return stringview(str + start, static_cast<size_t>(new_len)); }
 
     const char* str;
     std::size_t len;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,10 +4,7 @@ enable_testing()
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/.. ${Boost_INCLUDE_DIRS})
 
-
-set(CMAKE_CXX_STANDARD 14)
-add_definitions(-std=c++14) # For old cmake versions
-add_definitions(-Wall -Wextra)
+set(CMAKE_CXX_STANDARD 17)
 
 #add_executable(iod_query_stl iod_query_stl.cc)
 #add_test(iod_query_stl iod_query_stl)
@@ -16,52 +13,127 @@ add_definitions(-Wall -Wextra)
 #add_test(iod_query_sql iod_query_sql)
 
 add_executable(json json.cc)
+target_compile_options(
+    json 
+    PRIVATE
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-std=c++14 -Wall -Wextra -Wconversion -Wsign-conversion>
+        $<$<CXX_COMPILER_ID:MSVC>:/W4 /permissive->)
 add_test(json json)
 
 add_executable(core core.cc)
+target_compile_options(
+    core 
+    PRIVATE
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-std=c++14 -Wall -Wextra -Wconversion -Wsign-conversion>
+        $<$<CXX_COMPILER_ID:MSVC>:/W4 /permissive->)
 add_test(core core)
 
 
 add_executable(options options.cc)
+target_compile_options(
+    options 
+    PRIVATE
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-std=c++14 -Wall -Wextra -Wconversion -Wsign-conversion>
+        $<$<CXX_COMPILER_ID:MSVC>:/W4 /permissive->)
 add_test(options options)
 
 #add_executable(linq linq.cc)
 #add_test(linq linq)
 
 add_executable(callable_traits callable_traits.cc)
+target_compile_options(
+    callable_traits 
+    PRIVATE
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-std=c++14 -Wall -Wextra -Wconversion -Wsign-conversion>
+        $<$<CXX_COMPILER_ID:MSVC>:/W4 /permissive->)
 add_test(callable_traits callable_traits)
 
 add_executable(apply apply.cc)
+target_compile_options(
+    apply
+    PRIVATE
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-std=c++14 -Wall -Wextra -Wconversion -Wsign-conversion>
+        $<$<CXX_COMPILER_ID:MSVC>:/W4 /permissive->)
 add_test(apply apply)
 
 add_executable(foreach foreach.cc)
+target_compile_options(
+    foreach 
+    PRIVATE
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-std=c++14 -Wall -Wextra -Wconversion -Wsign-conversion>
+        $<$<CXX_COMPILER_ID:MSVC>:/W4 /permissive->)
 add_test(foreach foreach)
 
 add_executable(readme readme.cc)
+target_compile_options(
+    readme 
+    PRIVATE
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-std=c++14 -Wall -Wextra -Wconversion -Wsign-conversion>
+        $<$<CXX_COMPILER_ID:MSVC>:/W4 /permissive->)
 add_test(readme readme)
 
 add_executable(di di.cc)
+target_compile_options(
+    di 
+    PRIVATE
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-std=c++14 -Wall -Wextra -Wconversion -Wsign-conversion>
+        $<$<CXX_COMPILER_ID:MSVC>:/W4 /permissive->)
 add_test(di di)
 
 add_executable(bind_method bind_method.cc)
+target_compile_options(
+    bind_method 
+    PRIVATE
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-std=c++14 -Wall -Wextra -Wconversion -Wsign-conversion>
+        $<$<CXX_COMPILER_ID:MSVC>:/W4 /permissive->)
 add_test(bind_method bind_method)
 
 add_executable(tuple tuple.cc)
+target_compile_options(
+    tuple 
+    PRIVATE
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-std=c++14 -Wall -Wextra -Wconversion -Wsign-conversion>
+        $<$<CXX_COMPILER_ID:MSVC>:/W4 /permissive->)
 add_test(tuple tuple)
 
 add_executable(parse_command_line parse_command_line.cc)
+target_compile_options(
+    parse_command_line 
+    PRIVATE
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-std=c++14 -Wall -Wextra -Wconversion -Wsign-conversion>
+        $<$<CXX_COMPILER_ID:MSVC>:/W4 /permissive->)
 add_test(parse_command_line parse_command_line)
 
 add_executable(deep_merge deep_merge.cc)
+target_compile_options(
+    deep_merge 
+    PRIVATE
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-std=c++14 -Wall -Wextra -Wconversion -Wsign-conversion>
+        $<$<CXX_COMPILER_ID:MSVC>:/W4 /permissive->)
 add_test(deep_merge deep_merge)
 
 
 add_executable(array_view array_view.cc)
+target_compile_options(
+    array_view 
+    PRIVATE
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-std=c++14 -Wall -Wextra -Wconversion -Wsign-conversion>
+        $<$<CXX_COMPILER_ID:MSVC>:/W4 /permissive->)
 add_test(array_view array_view)
 
 add_executable(aos_view aos_view.cc)
+target_compile_options(
+    aos_view 
+    PRIVATE
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-std=c++14 -Wall -Wextra -Wconversion -Wsign-conversion>
+        $<$<CXX_COMPILER_ID:MSVC>:/W4 /permissive->)
 add_test(aos_view aos_view)
 
 
 add_executable(variable variable.cc)
+target_compile_options(
+    variable 
+    PRIVATE
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-std=c++14 -Wall -Wextra -Wconversion -Wsign-conversion>
+        $<$<CXX_COMPILER_ID:MSVC>:/W4 /permissive->)
 add_test(variable variable)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,7 +4,7 @@ enable_testing()
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/.. ${Boost_INCLUDE_DIRS})
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 14)
 
 #add_executable(iod_query_stl iod_query_stl.cc)
 #add_test(iod_query_stl iod_query_stl)
@@ -14,7 +14,7 @@ set(CMAKE_CXX_STANDARD 17)
 
 add_executable(json json.cc)
 target_compile_options(
-    json 
+    json
     PRIVATE
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-std=c++14 -Wall -Wextra -Wconversion -Wsign-conversion>
         $<$<CXX_COMPILER_ID:MSVC>:/W4 /permissive->)
@@ -22,7 +22,7 @@ add_test(json json)
 
 add_executable(core core.cc)
 target_compile_options(
-    core 
+    core
     PRIVATE
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-std=c++14 -Wall -Wextra -Wconversion -Wsign-conversion>
         $<$<CXX_COMPILER_ID:MSVC>:/W4 /permissive->)
@@ -31,7 +31,7 @@ add_test(core core)
 
 add_executable(options options.cc)
 target_compile_options(
-    options 
+    options
     PRIVATE
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-std=c++14 -Wall -Wextra -Wconversion -Wsign-conversion>
         $<$<CXX_COMPILER_ID:MSVC>:/W4 /permissive->)
@@ -42,7 +42,7 @@ add_test(options options)
 
 add_executable(callable_traits callable_traits.cc)
 target_compile_options(
-    callable_traits 
+    callable_traits
     PRIVATE
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-std=c++14 -Wall -Wextra -Wconversion -Wsign-conversion>
         $<$<CXX_COMPILER_ID:MSVC>:/W4 /permissive->)
@@ -58,7 +58,7 @@ add_test(apply apply)
 
 add_executable(foreach foreach.cc)
 target_compile_options(
-    foreach 
+    foreach
     PRIVATE
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-std=c++14 -Wall -Wextra -Wconversion -Wsign-conversion>
         $<$<CXX_COMPILER_ID:MSVC>:/W4 /permissive->)
@@ -66,7 +66,7 @@ add_test(foreach foreach)
 
 add_executable(readme readme.cc)
 target_compile_options(
-    readme 
+    readme
     PRIVATE
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-std=c++14 -Wall -Wextra -Wconversion -Wsign-conversion>
         $<$<CXX_COMPILER_ID:MSVC>:/W4 /permissive->)
@@ -74,7 +74,7 @@ add_test(readme readme)
 
 add_executable(di di.cc)
 target_compile_options(
-    di 
+    di
     PRIVATE
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-std=c++14 -Wall -Wextra -Wconversion -Wsign-conversion>
         $<$<CXX_COMPILER_ID:MSVC>:/W4 /permissive->)
@@ -82,7 +82,7 @@ add_test(di di)
 
 add_executable(bind_method bind_method.cc)
 target_compile_options(
-    bind_method 
+    bind_method
     PRIVATE
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-std=c++14 -Wall -Wextra -Wconversion -Wsign-conversion>
         $<$<CXX_COMPILER_ID:MSVC>:/W4 /permissive->)
@@ -90,7 +90,7 @@ add_test(bind_method bind_method)
 
 add_executable(tuple tuple.cc)
 target_compile_options(
-    tuple 
+    tuple
     PRIVATE
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-std=c++14 -Wall -Wextra -Wconversion -Wsign-conversion>
         $<$<CXX_COMPILER_ID:MSVC>:/W4 /permissive->)
@@ -98,7 +98,7 @@ add_test(tuple tuple)
 
 add_executable(parse_command_line parse_command_line.cc)
 target_compile_options(
-    parse_command_line 
+    parse_command_line
     PRIVATE
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-std=c++14 -Wall -Wextra -Wconversion -Wsign-conversion>
         $<$<CXX_COMPILER_ID:MSVC>:/W4 /permissive->)
@@ -106,7 +106,7 @@ add_test(parse_command_line parse_command_line)
 
 add_executable(deep_merge deep_merge.cc)
 target_compile_options(
-    deep_merge 
+    deep_merge
     PRIVATE
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-std=c++14 -Wall -Wextra -Wconversion -Wsign-conversion>
         $<$<CXX_COMPILER_ID:MSVC>:/W4 /permissive->)
@@ -115,7 +115,7 @@ add_test(deep_merge deep_merge)
 
 add_executable(array_view array_view.cc)
 target_compile_options(
-    array_view 
+    array_view
     PRIVATE
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-std=c++14 -Wall -Wextra -Wconversion -Wsign-conversion>
         $<$<CXX_COMPILER_ID:MSVC>:/W4 /permissive->)
@@ -123,7 +123,7 @@ add_test(array_view array_view)
 
 add_executable(aos_view aos_view.cc)
 target_compile_options(
-    aos_view 
+    aos_view
     PRIVATE
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-std=c++14 -Wall -Wextra -Wconversion -Wsign-conversion>
         $<$<CXX_COMPILER_ID:MSVC>:/W4 /permissive->)
@@ -132,7 +132,7 @@ add_test(aos_view aos_view)
 
 add_executable(variable variable.cc)
 target_compile_options(
-    variable 
+    variable
     PRIVATE
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-std=c++14 -Wall -Wextra -Wconversion -Wsign-conversion>
         $<$<CXX_COMPILER_ID:MSVC>:/W4 /permissive->)

--- a/tests/aos_view.cc
+++ b/tests/aos_view.cc
@@ -29,7 +29,7 @@ int main()
     for (auto x : v)
       std::cout << x.a << " " << x.b << std::endl;
     
-    for (size_t i = 0; i < v.size(); i++)
+    for (int i = 0; i < static_cast<int>(v.size()); i++)
       std::cout << v[i].a << " " << v[i].b << std::endl;
 
     // Views are writable.
@@ -80,7 +80,7 @@ int main()
     std::vector<int> A = {1,2,3,4};
 
     auto v = aos_view(_a = A,
-                      _b = [&] (int i) { return A[i] * 2; });
+                      _b = [&] (int i) { return A[static_cast<size_t>(i)] * 2; });
 
     for (auto x : v)
       std::cout << x.a << " " << x.b << std::endl;
@@ -99,7 +99,7 @@ int main()
 
     auto v = aos_view(_a = A,
                       _b = [&] (int i, std::string s) {
-                        std::cout << A[i] << s << std::endl ; });
+                        std::cout << A[static_cast<size_t>(i)] << s << std::endl ; });
 
     v[2].b("xx");
 

--- a/tests/apply.cc
+++ b/tests/apply.cc
@@ -37,8 +37,8 @@ int main()
 
   {
     // Forward
-    auto t = std::make_tuple(1, 2, 3);
-    auto fun = [] (auto t) { return std::get<0>(t); };
-    iod::apply(forward(t), fun);
+    auto t123 = std::make_tuple(1, 2, 3);
+    auto fun = [] (auto t123) { return std::get<0>(t123); };
+    iod::apply(forward(t123), fun);
   }
 }

--- a/tests/array_view.cc
+++ b/tests/array_view.cc
@@ -10,12 +10,12 @@ int main()
 
   {
     std::vector<int> A = {1,2,3,4};
-    auto v = array_view(A.size(), [&A] (int i) {
-        return  A[i] * 2;
+    auto v = array_view(static_cast<int>(A.size()), [&A] (int i) {
+        return  A[static_cast<size_t>(i)] * 2;
       });
 
-    for (int i = 0; i < int(v.size()); i++)
-      assert(v[i] == (A[i] * 2));
+    for (int i = 0; i < static_cast<int>(v.size()); i++)
+      assert(v[i] == (A[static_cast<size_t>(i)] * 2));
 
     for (auto x : v) std::cout << x << std::endl;
   }

--- a/tests/bind_method.cc
+++ b/tests/bind_method.cc
@@ -4,7 +4,7 @@
 
 struct A
 {
-  int add(int a, float b) { return a + b; }
+  int add(int a, float b) { return a + static_cast<int>(b); }
 };
 
 int main()

--- a/tests/di.cc
+++ b/tests/di.cc
@@ -127,7 +127,7 @@ void fun8(NC&)
 
 struct int_factory
 {
-  int instantiate(float f) { return f + 1; }
+  int instantiate(float f) { return static_cast<int>(f + 1); }
 };
 
 struct float_factory
@@ -199,7 +199,7 @@ int main()
   // typedef decltype(t) T2;
   // static_assert(iod::di::tuple_embeds_fun_with_return_type<T2, int>::value, "");
   iod::di_call(&fun1);
-  iod::di_call(&fun1, 1);
+  iod::di_call(&fun1, 1); // warning because parameter isn't used by fun1()
   iod::di_call(&fun2, 1);
   iod::di_call(&fun3, y, x);
   iod::di_call(&fun3, y, x, A());

--- a/tests/json.cc
+++ b/tests/json.cc
@@ -95,7 +95,7 @@ int main()
     str = R"({"city":  "te{}}{}\"st\\"}})";
     json_decode(c, str);
     std::cout << c.city.str << std::endl;
-    assert(c.city.str == R"("te{}}{}\"st\\")");
+    assert(c.city.str == "\"te{}}{}\\\"st\\\\\"");
 
     str = R"({"city":  "test", "name": "john"})";
     json_decode(c2, str);
@@ -145,7 +145,7 @@ int main()
   // Encode strings
   {
     auto object = iod::D(_name = "\"");
-    assert(iod::json_encode(object) == R"({"name":"\""})");
+    assert(iod::json_encode(object) == "{\"name\":\"\\\"\"}");
   }
 
 }

--- a/tests/parse_command_line.cc
+++ b/tests/parse_command_line.cc
@@ -119,7 +119,7 @@ int main()
                                      _opt1 | _1 = int(),
                                      _opt2 | _2 = std::string());
     }
-    catch (std::runtime_error e)
+    catch (std::runtime_error &e)
     {
       err = e.what();
     };

--- a/tests/tuple.cc
+++ b/tests/tuple.cc
@@ -18,7 +18,7 @@ int main()
 
   assert(std::tuple_size<decltype(t2)>::value == 1);
 
-  std::tuple<int, float, int, double> t3{1, 2, 3, 4};
+  std::tuple<int, float, int, double> t3{1, 2.f, 3, 4.};
   auto t4 = tuple_filter<std::is_floating_point>(t3);
   std::cout << std::tuple_size<decltype(t4)>::value << std::endl;
   assert(std::get<0>(t4) == 2);

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -4,6 +4,12 @@ project(Iod)
 set(CMAKE_CXX_STANDARD 14)
 
 add_executable(iod_generate_symbols iod_generate_symbols.cc)
+target_compile_options(
+    iod_generate_symbols 
+    PRIVATE
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-std=c++14>
+        $<$<CXX_COMPILER_ID:MSVC>:/permissive->
+)
 
 install(TARGETS iod_generate_symbols
         DESTINATION bin)

--- a/tools/iod_generate_symbols.cc
+++ b/tools/iod_generate_symbols.cc
@@ -67,7 +67,7 @@ int main(int argc, char* argv[])
 
         bool is_type = s.size() >= 2 and s[s.size() - 2] == '_' and s[s.size() - 1] == 't';
         
-        if (!std::isalnum(m[0]) and !is_in_string(what.position()) and
+        if (!std::isalnum(m[0]) and !is_in_string(static_cast<int>(what.position())) and
             !is_type and keywords.find(s) == keywords.end())
           symbols.insert(what[1]);
         start = what[0].second;      


### PR DESCRIPTION
Had a requirement for MSVC so I made the port. I have tested on Windows and Linux/gcc but not clang by running all executables in the tests directory.

The port was mostly straightforward except for one possible MSVC bug with a workaround in the sio class.

Along with the port, I did a lot of minor changes (mostly static_cast<>) to get rid of warnings.